### PR TITLE
Last `n` History

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,6 +12,8 @@ blocklist = [
 # password = <OPTIONAL: your password>
 
 threshold = 0.9
+last_n_history = 5
+
 timezone = -5 # in UTC-<hour> format
 
 database = "data.db"

--- a/src/api.rs
+++ b/src/api.rs
@@ -66,7 +66,7 @@ pub trait AsBuild {
 /// Jobs that can be represented as [Job]
 pub trait AsJob {
     /// Convert `&self` to [Job]
-    fn as_job(&self) -> crate::db::Job;
+    fn as_job(&self, last_n: usize) -> crate::db::Job;
 }
 
 /// [Build]s with common fields
@@ -107,10 +107,10 @@ impl Job for SparseJob {
 }
 
 impl AsJob for SparseJob {
-    fn as_job(&self) -> crate::db::Job {
+    fn as_job(&self, last_n: usize) -> crate::db::Job {
         crate::db::Job {
             name: self.name.clone(),
-            last_build: self.builds.first().map(|b| b.number),
+            last_build: self.builds.iter().take(last_n).last().map(|b| b.number),
             url: self.url.clone(),
         }
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -28,7 +28,7 @@ pub struct SparseJob {
     pub url: String,
 
     /// Last build of job as a [SparseBuild]
-    pub last_build: Option<SparseBuild>,
+    pub builds: Vec<SparseBuild>,
 }
 
 /// Represents a job build pulled from [SparseMatrixProject::pull_jobs]
@@ -110,7 +110,7 @@ impl AsJob for SparseJob {
     fn as_job(&self) -> crate::db::Job {
         crate::db::Job {
             name: self.name.clone(),
-            last_build: self.last_build.as_ref().map(|b| b.number),
+            last_build: self.builds.first().map(|b| b.number),
             url: self.url.clone(),
         }
     }
@@ -170,7 +170,7 @@ impl SparseMatrixProject {
                             .with_subfield("name")
                             .with_subfield("url")
                             .with_subfield(
-                                TreeBuilder::object("lastBuild")
+                                TreeBuilder::object("builds")
                                     .with_subfield("number")
                                     .with_subfield("url")
                                     .with_subfield("displayName")

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,9 @@ pub struct Config {
     /// Optional password
     pub password: Option<String>,
 
+    /// Last N builds to preserve for history
+    pub last_n_history: usize,
+
     /// Threshold for similarity calculation
     pub threshold: f32,
 

--- a/src/db/build.rs
+++ b/src/db/build.rs
@@ -114,32 +114,32 @@ impl JobBuild {
                 JOIN runs ON runs.id = issues.run_id
                 JOIN builds ON builds.id = runs.build_id
                 JOIN jobs ON jobs.id = builds.job_id
-                WHERE number != last_build
+                WHERE number < last_build
             );
             DELETE FROM issues WHERE id IN (
                 SELECT issues.id FROM issues
                 JOIN runs ON runs.id = issues.run_id
                 JOIN builds ON builds.id = runs.build_id
                 JOIN jobs ON jobs.id = builds.job_id
-                WHERE number != last_build
+                WHERE number < last_build
             );
             DELETE FROM artifacts WHERE id IN (
                 SELECT artifacts.id FROM artifacts
                 JOIN runs ON runs.id = artifacts.run_id
                 JOIN builds ON builds.id = runs.build_id
                 JOIN jobs ON jobs.id = builds.job_id
-                WHERE number != last_build
+                WHERE number < last_build
             );
             DELETE FROM runs WHERE id IN (
                 SELECT runs.id FROM runs
                 JOIN builds ON builds.id = runs.build_id
                 JOIN jobs ON jobs.id = builds.job_id
-                WHERE number != last_build
+                WHERE number < last_build
             );
             DELETE FROM builds WHERE id IN (
                 SELECT builds.id FROM builds
                 JOIN jobs ON jobs.id = builds.job_id
-                WHERE number != last_build
+                WHERE number < last_build
             );
             COMMIT;
             ",

--- a/src/db/build.rs
+++ b/src/db/build.rs
@@ -103,6 +103,22 @@ impl JobBuild {
         .query_one((job_id, number), Self::map_row(params))
     }
 
+    /// Get all [JobBuild] from [super::Database] by [super::Job]
+    pub fn select_all_by_job(
+        db: &super::Database,
+        job_id: i64,
+        params: (),
+    ) -> rusqlite::Result<Vec<super::InDatabase<Self>>> {
+        db.prepare_cached(
+            "
+                SELECT * FROM builds
+                WHERE job_id = ?
+                ",
+        )?
+        .query_map((job_id,), Self::map_row(params))?
+        .collect()
+    }
+
     /// Remove all [JobBuild]s which aren't referenced by [super::Job] from [super::Database]
     pub fn delete_all_orphan(db: &super::Database) -> rusqlite::Result<()> {
         db.execute_batch(

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -156,7 +156,7 @@ macro_rules! for_all {
     };
 
     ($($method:tt)+) => {
-        for_all!([Artifact, Job, JobBuild, Run, Issue, TagInfo, SimilarityInfo] => $($method)+)
+        for_all!([SimilarityInfo, Issue, Artifact, Run, JobBuild, Job, TagInfo] => $($method)+)
     };
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -634,7 +634,7 @@ async fn main() -> Result<()> {
 
         copy_artifacts("artifacts", artifact, &database).await?;
 
-        let markup = task::spawn_blocking(move || {
+        let markup = task::spawn(async move {
             page::render(
                 &database,
                 &view,
@@ -642,16 +642,15 @@ async fn main() -> Result<()> {
             )
             .unwrap()
             .into_string()
-        })
-        .await?;
+        });
 
         if let Some(filepath) = output {
-            fs::write(&filepath, markup).await?;
+            fs::write(&filepath, markup.await?).await?;
 
             info!("Written to {filepath}");
         } else {
             info!("Dumping to stdout --");
-            println!("{markup}");
+            println!("{}", markup.await?);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ async fn pull_build_logs(
                     .is_none()
         })
         .map(|sj| {
-            let job: Arc<_> = sj.as_job().upsert(db, ())?.into();
+            let job: Arc<_> = sj.as_job(last_n_history).upsert(db, ())?.into();
             Ok(sj
                 .builds
                 .into_iter()

--- a/src/page.rs
+++ b/src/page.rs
@@ -244,7 +244,7 @@ fn render_stats(db: &Database) -> Result<Markup> {
     let stats = Statistics::query(db)?;
     Ok(html! {
         h3 {
-            "Run Statistics"
+            "Job Statistics"
         }
         p {
             "Overall Job Health:"
@@ -257,7 +257,7 @@ fn render_stats(db: &Database) -> Result<Markup> {
         }
 
         h4 {
-            "Run Status"
+            "Latest Run Statuses"
         }
         table class="view" {
             tr {
@@ -486,7 +486,7 @@ pub fn render(db: &Database, views: &[TagView], tz: UtcOffset) -> Result<Markup>
             }
             body {
                 h1 {
-                    "Job Status"
+                    "build-pulse"
                 }
                 (render_stats(db)?)
                 (render_similarities(db)?)

--- a/src/page.rs
+++ b/src/page.rs
@@ -351,15 +351,14 @@ fn render_stats(db: &Database) -> Result<Markup> {
 
 /// Render [crate::db::Similarity]
 fn render_similarities(db: &Database) -> Result<Markup> {
-    let similarities: HashMap<_, Vec<_>> = Similarity::query_all(db, ())?
-        .into_iter()
-        // ignore similarities within the same run
-        .filter(|s| s.related.len() > 1)
-        .fold(HashMap::new(), |mut acc, s| {
-            acc.entry(s.tag.severity).or_default().push(s);
+    let similarities: HashMap<_, Vec<_>> =
+        Similarity::query_all(db, ())?
+            .into_iter()
+            .fold(HashMap::new(), |mut acc, s| {
+                acc.entry(s.tag.severity).or_default().push(s);
 
-            acc
-        });
+                acc
+            });
 
     Ok(html! {
         h4 {

--- a/src/tag_expr.rs
+++ b/src/tag_expr.rs
@@ -183,9 +183,13 @@ impl TagExpr {
         Ok((
             format!(
                 "
-                SELECT DISTINCT runs.id FROM runs
-                WHERE
-                {where_expr}
+                SELECT DISTINCT id FROM runs
+                WHERE {where_expr}
+                    AND build_id IN (
+                        SELECT id FROM builds
+                        GROUP BY job_id
+                        HAVING MAX(number)
+                    )
                 "
             ),
             params_from_iter(params),


### PR DESCRIPTION
Enables `build-pulse` to pull more than just the last build for each job. Additionally introduces rate-limits to prevent hitting resource ceilings.

**todo**

- [x] Refactor page to display new builds
- [x] ~~Rename `last_build` column in `jobs`~~ Decided to keep the same name.
- [ ] more...