### PR TITLE
Async DB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "chumsky",
  "clap",
  "env_logger",
+ "futures",
  "jenkins_api",
  "log",
  "maud",
@@ -166,6 +167,7 @@ dependencies = [
  "serde_json",
  "time",
  "tokio",
+ "tokio-stream",
  "toml",
 ]
 
@@ -393,12 +395,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -406,6 +424,40 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -419,10 +471,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1554,6 +1612,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,5 @@ chumsky = { version = "0.10.1", features = ["pratt"] }
 rusqlite_regex = "0.6.0"
 arcstr = "1.2.0"
 tokio = { version = "1.47.1", features = ["fs", "macros", "process", "rt-multi-thread"] }
+tokio-stream = "0.1.17"
+futures = "0.3.31"

--- a/src/api.rs
+++ b/src/api.rs
@@ -109,9 +109,9 @@ impl Job for SparseJob {
 impl AsJob for SparseJob {
     fn as_job(&self, last_n: usize) -> crate::db::Job {
         crate::db::Job {
-            name: self.name.clone(),
+            name: self.name.as_str().into(),
             last_build: self.builds.iter().take(last_n).last().map(|b| b.number),
-            url: self.url.clone(),
+            url: self.url.as_str().into(),
         }
     }
 }
@@ -136,7 +136,7 @@ where
         let display_name = self.full_display_name_or_default();
         let status = self.build_status();
         Run {
-            url: self.url().to_string(),
+            url: self.url().into(),
             status,
             display_name: display_name.into(),
             log: match status {

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,7 +66,7 @@ pub struct TagView {
     pub expr: String,
 }
 
-/// Represents one tag to be loaded as [crate::parse::Tag]
+/// Represents one tag to be loaded as [crate::db::TagInfo]
 #[derive(Deserialize)]
 pub struct ConfigTag {
     /// Unique name of the tag

--- a/src/db/artifact.rs
+++ b/src/db/artifact.rs
@@ -30,7 +30,7 @@ schema! {
     }
 }
 
-impl Queryable<'_> for Artifact {
+impl Queryable for Artifact {
     fn map_row(row: &rusqlite::Row) -> rusqlite::Result<super::InDatabase<Self>> {
         Ok(super::InDatabase::new(
             row.get(0)?,

--- a/src/db/artifact.rs
+++ b/src/db/artifact.rs
@@ -2,7 +2,7 @@ use crate::{db::Queryable, schema};
 
 /// [Artifact] stored in [super::Database]
 pub struct Artifact {
-    /// Byte contents of [Artifact]
+    /// Path of the [Artifact]
     pub path: String,
 
     /// Byte contents of [Artifact]

--- a/src/db/artifact.rs
+++ b/src/db/artifact.rs
@@ -30,40 +30,40 @@ schema! {
     }
 }
 
-impl Queryable for Artifact {
-    fn map_row(_: ()) -> impl FnMut(&rusqlite::Row) -> rusqlite::Result<super::InDatabase<Self>> {
-        |row| {
-            Ok(super::InDatabase::new(
-                row.get(0)?,
-                Artifact {
-                    path: row.get(1)?,
-                    contents: row.get(2)?,
-                    run_id: row.get(3)?,
-                },
-            ))
-        }
+impl Queryable<'_> for Artifact {
+    fn map_row(row: &rusqlite::Row) -> rusqlite::Result<super::InDatabase<Self>> {
+        Ok(super::InDatabase::new(
+            row.get(0)?,
+            Artifact {
+                path: row.get(1)?,
+                contents: row.get(2)?,
+                run_id: row.get(3)?,
+            },
+        ))
     }
 
-    fn as_params(&self, _: ()) -> rusqlite::Result<impl rusqlite::Params> {
+    fn as_params(&self) -> rusqlite::Result<impl rusqlite::Params> {
         Ok((&self.path, &self.contents, self.run_id))
     }
 }
 
 impl Artifact {
     /// Get all [Artifact] from [super::Database] by [super::Run]
-    pub fn select_all_by_run(
+    pub async fn select_all_by_run(
         db: &super::Database,
         run_id: i64,
-        params: (),
     ) -> rusqlite::Result<Vec<super::InDatabase<Self>>> {
-        db.prepare_cached(
-            "
+        db.call(move |conn| {
+            conn.prepare_cached(
+                "
                 SELECT * FROM artifacts
                 WHERE run_id = ?
                 ",
-        )?
-        .query_map((run_id,), Self::map_row(params))?
-        .collect()
+            )?
+            .query_map((run_id,), Self::map_row)?
+            .collect()
+        })
+        .await
     }
 
     /// Gets the [BlobFormat] of the [Artifact]

--- a/src/db/build.rs
+++ b/src/db/build.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 /// [JobBuild] in [super::Database]
+#[derive(Clone)]
 pub struct JobBuild {
     /// Build url
     pub url: String,

--- a/src/db/build.rs
+++ b/src/db/build.rs
@@ -34,7 +34,7 @@ schema! {
     }
 }
 
-impl Queryable<'_> for JobBuild {
+impl Queryable for JobBuild {
     fn map_row(row: &rusqlite::Row) -> rusqlite::Result<super::InDatabase<Self>> {
         Ok(super::InDatabase::new(
             row.get(0)?,
@@ -59,7 +59,7 @@ impl Queryable<'_> for JobBuild {
     }
 }
 
-impl Upsertable<'_> for JobBuild {
+impl Upsertable for JobBuild {
     async fn upsert(self, db: &super::Database) -> rusqlite::Result<super::InDatabase<Self>> {
         let number = self.number;
         let job_id = self.job_id;

--- a/src/db/issue.rs
+++ b/src/db/issue.rs
@@ -40,7 +40,7 @@ schema! {
     }
 }
 
-impl Queryable<'_> for IssueInfo {
+impl Queryable for IssueInfo {
     fn map_row(row: &rusqlite::Row) -> rusqlite::Result<super::InDatabase<Self>> {
         Ok(super::InDatabase::new(
             row.get(0)?,

--- a/src/db/job.rs
+++ b/src/db/job.rs
@@ -1,3 +1,6 @@
+use arcstr::ArcStr;
+use futures::{StreamExt, TryStreamExt, stream};
+
 use crate::{
     db::{Queryable, Upsertable},
     schema,
@@ -6,10 +9,10 @@ use crate::{
 /// [Job] stored in [super::Database]
 pub struct Job {
     /// Unique name of [Job]
-    pub name: String,
+    pub name: ArcStr,
 
     /// [Job] url
-    pub url: String,
+    pub url: ArcStr,
 
     /// Number of last [super::JobBuild]
     pub last_build: Option<u32>,
@@ -24,29 +27,29 @@ schema! {
     }
 }
 
-impl Queryable for Job {
-    fn map_row(_: ()) -> impl FnMut(&rusqlite::Row) -> rusqlite::Result<super::InDatabase<Self>> {
-        |row| {
-            Ok(super::InDatabase::new(
-                row.get(0)?,
-                Job {
-                    name: row.get(1)?,
-                    url: row.get(2)?,
-                    last_build: row.get(3)?,
-                },
-            ))
-        }
+impl Queryable<'_> for Job {
+    fn map_row(row: &rusqlite::Row) -> rusqlite::Result<super::InDatabase<Self>> {
+        Ok(super::InDatabase::new(
+            row.get(0)?,
+            Job {
+                name: row.get::<_, String>(1)?.into(),
+                url: row.get::<_, String>(2)?.into(),
+                last_build: row.get(3)?,
+            },
+        ))
     }
 
-    fn as_params(&self, _: ()) -> rusqlite::Result<impl rusqlite::Params> {
-        Ok((&self.name, &self.url, self.last_build))
+    fn as_params(&self) -> rusqlite::Result<impl rusqlite::Params> {
+        Ok((self.name.as_str(), self.url.as_str(), self.last_build))
     }
 }
 
-impl Upsertable for Job {
-    fn upsert(self, db: &super::Database, params: ()) -> rusqlite::Result<super::InDatabase<Self>> {
-        db.prepare_cached(
-            "
+impl Upsertable<'_> for Job {
+    async fn upsert(self, db: &super::Database) -> rusqlite::Result<super::InDatabase<Self>> {
+        let name = self.name.clone();
+        db.call(move |conn| {
+            conn.prepare_cached(
+                "
                 INSERT INTO jobs (
                     name,
                     url,
@@ -55,109 +58,122 @@ impl Upsertable for Job {
                     ON CONFLICT(name) DO UPDATE SET
                         last_build = excluded.last_build
                 ",
-        )?
-        .execute(self.as_params(params)?)?;
+            )?
+            .execute(self.as_params()?)
+        })
+        .await?;
 
         // get the job as a second query in-case of an insert conflict
-        Self::select_one_by_name(db, &self.name, ())
+        Self::select_one_by_name(db, name).await
     }
 }
 
 impl Job {
     /// Get a [Job] from [super::Database] by name
-    pub fn select_one_by_name(
+    pub async fn select_one_by_name(
         db: &super::Database,
-        name: &str,
-        params: (),
+        name: ArcStr,
     ) -> rusqlite::Result<super::InDatabase<Self>> {
-        db.prepare_cached(
-            "
+        db.call(move |conn| {
+            conn.prepare_cached(
+                "
                 SELECT * FROM jobs
                 WHERE name = ?
                 ",
-        )?
-        .query_one((name,), Self::map_row(params))
+            )?
+            .query_one((name.as_str(),), Self::map_row)
+        })
+        .await
     }
 
     /// Remove all [Job]s from [super::Database] by name
-    pub fn delete_all_by_blocklist(
-        db: &mut super::Database,
-        names: &[String],
-    ) -> rusqlite::Result<usize> {
-        let mut tx = db.transaction()?;
-        tx.set_drop_behavior(rusqlite::DropBehavior::Commit);
+    pub async fn delete_all_by_blocklist<I>(
+        db: &super::Database,
+        names: I,
+    ) -> rusqlite::Result<usize>
+    where
+        I: IntoIterator<Item = String>,
+    {
+        stream::iter(names)
+            .then(|name| async {
+                db.call(move |conn| {
+                    let mut tx = conn.unchecked_transaction()?;
+                    tx.set_drop_behavior(rusqlite::DropBehavior::Commit);
 
-        names.iter().try_fold(0, |acc, name| {
-            // delete similarities first
-            tx.execute(
-                "
-                DELETE FROM similarities WHERE similarity_hash IN (
-                    SELECT DISTINCT similarities.similarity_hash FROM similarities
-                    JOIN issues ON issues.id = similarities.issue_id
-                    JOIN runs ON runs.id = issues.run_id
-                    JOIN builds ON builds.id = runs.build_id
-                    JOIN jobs ON jobs.id = builds.job_id
-                    WHERE name = ?
-                )
-                ",
-                (name,),
-            )?;
+                    // delete similarities first
+                    tx.execute(
+                        "
+                        DELETE FROM similarities WHERE similarity_hash IN (
+                            SELECT DISTINCT similarities.similarity_hash FROM similarities
+                            JOIN issues ON issues.id = similarities.issue_id
+                            JOIN runs ON runs.id = issues.run_id
+                            JOIN builds ON builds.id = runs.build_id
+                            JOIN jobs ON jobs.id = builds.job_id
+                            WHERE name = ?
+                        )
+                        ",
+                        (&name,),
+                    )?;
 
-            // then issues
-            tx.execute(
-                "
-                DELETE FROM issues WHERE id IN (
-                    SELECT issues.id FROM issues
-                    JOIN runs ON runs.id = issues.run_id
-                    JOIN builds ON builds.id = runs.build_id
-                    JOIN jobs ON jobs.id = builds.job_id
-                    WHERE name = ?
-                )
-                ",
-                (name,),
-            )?;
+                    // then issues
+                    tx.execute(
+                        "
+                        DELETE FROM issues WHERE id IN (
+                            SELECT issues.id FROM issues
+                            JOIN runs ON runs.id = issues.run_id
+                            JOIN builds ON builds.id = runs.build_id
+                            JOIN jobs ON jobs.id = builds.job_id
+                            WHERE name = ?
+                        )
+                        ",
+                        (&name,),
+                    )?;
 
-            // then artifacts
-            tx.execute(
-                "
-                DELETE FROM artifacts WHERE id IN (
-                    SELECT artifacts.id FROM artifacts
-                    JOIN runs ON runs.id = artifacts.run_id
-                    JOIN builds ON builds.id = runs.build_id
-                    JOIN jobs ON jobs.id = builds.job_id
-                    WHERE name = ?
-                );
-                ",
-                (name,),
-            )?;
+                    // then artifacts
+                    tx.execute(
+                        "
+                        DELETE FROM artifacts WHERE id IN (
+                            SELECT artifacts.id FROM artifacts
+                            JOIN runs ON runs.id = artifacts.run_id
+                            JOIN builds ON builds.id = runs.build_id
+                            JOIN jobs ON jobs.id = builds.job_id
+                            WHERE name = ?
+                        );
+                        ",
+                        (&name,),
+                    )?;
 
-            // then runs
-            tx.execute(
-                "
-                DELETE FROM runs WHERE id IN (
-                    SELECT runs.id FROM runs
-                    JOIN builds ON builds.id = runs.build_id
-                    JOIN jobs ON jobs.id = builds.job_id
-                    WHERE name = ?
-                );
-                ",
-                (name,),
-            )?;
+                    // then runs
+                    tx.execute(
+                        "
+                        DELETE FROM runs WHERE id IN (
+                            SELECT runs.id FROM runs
+                            JOIN builds ON builds.id = runs.build_id
+                            JOIN jobs ON jobs.id = builds.job_id
+                            WHERE name = ?
+                        );
+                        ",
+                        (&name,),
+                    )?;
 
-            // then builds
-            tx.execute(
-                "
-                DELETE FROM builds WHERE id IN (
-                    SELECT builds.id FROM builds
-                    JOIN jobs ON jobs.id = builds.job_id
-                    WHERE name = ?
-                );
-                ",
-                (name,),
-            )?;
+                    // then builds
+                    tx.execute(
+                        "
+                        DELETE FROM builds WHERE id IN (
+                            SELECT builds.id FROM builds
+                            JOIN jobs ON jobs.id = builds.job_id
+                            WHERE name = ?
+                        );
+                        ",
+                        (&name,),
+                    )?;
 
-            // finally the job
-            Ok(acc + tx.execute("DELETE FROM jobs WHERE name = ?", (name,))?)
-        })
+                    // finally the job
+                    tx.execute("DELETE FROM jobs WHERE name = ?", (&name,))
+                })
+                .await
+            })
+            .try_fold(0, |acc, x| async move { Ok(acc + x) })
+            .await
     }
 }

--- a/src/db/job.rs
+++ b/src/db/job.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 /// [Job] stored in [super::Database]
+#[derive(Clone)]
 pub struct Job {
     /// Unique name of [Job]
     pub name: ArcStr,

--- a/src/db/job.rs
+++ b/src/db/job.rs
@@ -27,7 +27,7 @@ schema! {
     }
 }
 
-impl Queryable<'_> for Job {
+impl Queryable for Job {
     fn map_row(row: &rusqlite::Row) -> rusqlite::Result<super::InDatabase<Self>> {
         Ok(super::InDatabase::new(
             row.get(0)?,
@@ -44,7 +44,7 @@ impl Queryable<'_> for Job {
     }
 }
 
-impl Upsertable<'_> for Job {
+impl Upsertable for Job {
     async fn upsert(self, db: &super::Database) -> rusqlite::Result<super::InDatabase<Self>> {
         let name = self.name.clone();
         db.call(move |conn| {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -321,7 +321,10 @@ pub trait Schema: Send + Sized {
     }
 }
 
-pub trait Queryable<'a>: Schema {
+pub trait Queryable: Schema
+where
+    Self: 'static,
+{
     /// Convert [Row] to `Self` with params
     fn map_row(row: &Row) -> Result<InDatabase<Self>>;
 
@@ -340,7 +343,7 @@ pub trait Queryable<'a>: Schema {
 
     /// Select one of `Self` from [Database] by `id`
     async fn select_one(db: &Database, id: i64) -> Result<InDatabase<Self>> {
-        db.call(|conn| {
+        db.call(move |conn| {
             conn.prepare_cached(Self::SELECT_ONE)?
                 .query_one((id,), Self::map_row)
         })
@@ -363,7 +366,7 @@ pub trait Queryable<'a>: Schema {
     }
 }
 
-pub trait Upsertable<'a>: Queryable<'a> {
+pub trait Upsertable: Queryable {
     /// Upsert `self` to [Database]
     async fn upsert(self, db: &Database) -> Result<InDatabase<Self>>;
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -181,13 +181,14 @@ where
 }
 
 /// Database object
+#[derive(Clone)]
 pub struct Database {
     /// Sender to connection background thread
     tx: mpsc::UnboundedSender<Box<dyn Message>>,
 }
 
 /// Represents an item `T` in [Database]
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct InDatabase<T> {
     /// Row ID of `item`
     pub id: i64,

--- a/src/db/run.rs
+++ b/src/db/run.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 /// [Run] stored in [super::Database]
+#[derive(Clone)]
 pub struct Run {
     /// Run url
     pub url: ArcStr,

--- a/src/db/run.rs
+++ b/src/db/run.rs
@@ -41,7 +41,7 @@ schema! {
     }
 }
 
-impl Queryable<'_> for Run {
+impl Queryable for Run {
     fn map_row(row: &rusqlite::Row) -> rusqlite::Result<super::InDatabase<Self>> {
         Ok(super::InDatabase::new(
             row.get(0)?,
@@ -68,7 +68,7 @@ impl Queryable<'_> for Run {
     }
 }
 
-impl Upsertable<'_> for Run {
+impl Upsertable for Run {
     async fn upsert(self, db: &super::Database) -> rusqlite::Result<super::InDatabase<Self>> {
         let url = self.url.clone();
         db.call(move |conn| {

--- a/src/db/similarity.rs
+++ b/src/db/similarity.rs
@@ -34,7 +34,7 @@ schema! {
     }
 }
 
-impl Queryable<'_> for SimilarityInfo {
+impl Queryable for SimilarityInfo {
     fn map_row(row: &rusqlite::Row) -> rusqlite::Result<InDatabase<Self>> {
         Ok(InDatabase::new(
             row.get(0)?,

--- a/src/db/similarity.rs
+++ b/src/db/similarity.rs
@@ -162,15 +162,5 @@ impl Similarity {
         )
         .map_ok(|hm| hm.into_values())
         .await
-
-        // let mut similarities: Vec<_> = hm
-        //     .into_values()
-        //     // ignore similarities within the same run
-        //     .filter(|s| s.related.len() > 1)
-        //     .collect();
-        //
-        // similarities.sort_by_cached_key(|s| Reverse(s.related.len()));
-        //
-        // Ok(similarities)
     }
 }

--- a/src/db/tag.rs
+++ b/src/db/tag.rs
@@ -44,7 +44,7 @@ schema! {
     }
 }
 
-impl Queryable<'_> for TagInfo {
+impl Queryable for TagInfo {
     fn map_row(row: &rusqlite::Row) -> rusqlite::Result<super::InDatabase<Self>> {
         Ok(super::InDatabase::new(
             row.get(0)?,
@@ -67,7 +67,7 @@ impl Queryable<'_> for TagInfo {
     }
 }
 
-impl Upsertable<'_> for TagInfo {
+impl Upsertable for TagInfo {
     async fn upsert(self, db: &super::Database) -> rusqlite::Result<super::InDatabase<Self>> {
         let name = self.name.clone();
         db.call(move |conn| {

--- a/src/db/tag.rs
+++ b/src/db/tag.rs
@@ -1,7 +1,7 @@
 use arcstr::ArcStr;
 
 use crate::{
-    config::{Field, Severity},
+    config::{ConfigTag, Field, Severity},
     db::{Queryable, Run, Upsertable},
     read_value, schema, write_value,
 };
@@ -28,6 +28,17 @@ schema! {
         desc            TEXT NOT NULL,
         field           TEXT NOT NULL,
         severity        TEXT NOT NULL
+    }
+}
+
+impl From<ConfigTag> for TagInfo {
+    fn from(value: ConfigTag) -> Self {
+        Self {
+            name: value.name.into(),
+            desc: value.desc.into(),
+            field: value.from,
+            severity: value.severity,
+        }
     }
 }
 
@@ -113,11 +124,11 @@ impl TagInfo {
         db.call(|conn| {
             conn.execute(
                 "
-            DELETE FROM tags WHERE NOT EXISTS (
-                SELECT 1 FROM issues
-                WHERE tags.id = issues.tag_id
-            )
-            ",
+                DELETE FROM tags WHERE NOT EXISTS (
+                    SELECT 1 FROM issues
+                    WHERE tags.id = issues.tag_id
+                )
+                ",
                 (),
             )
         })

--- a/src/db/tag.rs
+++ b/src/db/tag.rs
@@ -3,7 +3,6 @@ use arcstr::ArcStr;
 use crate::{
     config::{Field, Severity},
     db::{Queryable, Run, Upsertable},
-    parse::Tag,
     read_value, schema, write_value,
 };
 
@@ -20,18 +19,6 @@ pub struct TagInfo {
 
     /// Severity of [Tag]
     pub severity: Severity,
-}
-
-impl From<&Tag> for TagInfo {
-    fn from(value: &Tag) -> Self {
-        TagInfo {
-            // FIXME: make [Tag]'s name and desc also be ArcStr
-            name: ArcStr::from(&value.name),
-            desc: ArcStr::from(&value.desc),
-            field: value.from,
-            severity: value.severity,
-        }
-    }
 }
 
 schema! {

--- a/src/db/tag.rs
+++ b/src/db/tag.rs
@@ -124,10 +124,3 @@ impl TagInfo {
         .await
     }
 }
-
-impl super::InDatabase<TagInfo> {
-    /// Converts [super::InDatabase<TagInfo>] into [super::InDatabase<Tag>]
-    pub fn into_tag(self, t: Tag) -> super::InDatabase<Tag> {
-        super::InDatabase::new(self.id, t)
-    }
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,7 +211,9 @@ impl TryPull<RunContext, InDatabase<Run>> for JenkinsPuller {
                                     run.display_name,
                                     e
                                 );
-                            });
+                            })
+                            .try_collect::<Vec<_>>()
+                            .await?;
 
                         log!(
                             match run.status {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -71,10 +71,10 @@ impl<T> PatternSet<T> {
     }
 
     /// Grep `field` for [Pattern]s
-    pub fn grep_matches(&self, field: &ArcStr) -> impl Iterator<Item = &Pattern<T>> {
+    pub fn grep_matches<S: AsRef<str>>(&self, field: S) -> impl Iterator<Item = &Pattern<T>> {
         // matches using the match set first, then the regex of all valid matches are ran again to find them
         self.pattern_set
-            .matches(&field)
+            .matches(field.as_ref())
             .into_iter()
             .map(|i| &self.patterns[i])
     }


### PR DESCRIPTION
This PR primarily refactors the database ORM to run asynchronously by dispatching accesses via a dedicated thread. In doing so, we're able to switch the processing of build issues to `impl Stream` and complete all required tasks in an asynchronous fashion.

Additional work is needed to parallelize driving these `Stream`s to completion to replicate the old runtime behavior with `rayon`. In addition, #3 may be mitigated by integrating concurrency limits and liberal timeout handling w/ while driving the `Stream`.